### PR TITLE
[WIP] fix: display unacquired data: from 0 to '-'

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -7,7 +7,7 @@
           <span v-html="$t('検査実施<br />人数')" />
           <!-- eslint-enable vue/no-v-html-->
           <span>
-            <b>{{ 検査実施人数 }}</b>
+            <b>{{ 検査実施人数 || '-' }}</b>
             <span class="unit">{{ $t('人') }}</span>
           </span>
         </div>
@@ -21,7 +21,7 @@
             <br />{{ $t('(累積)') }}
           </span>
           <span>
-            <b>{{ 陽性物数 }}</b>
+            <b>{{ 陽性物数 || '-' }}</b>
             <span class="unit">{{ $t('人') }}</span>
           </span>
         </div>
@@ -32,7 +32,7 @@
             <div class="box">
               <span>{{ $t('入院中') }}</span>
               <span>
-                <b>{{ 入院中 }}</b>
+                <b>{{ 入院中 || '-' }}</b>
                 <span class="unit">{{ $t('人') }}</span>
               </span>
             </div>
@@ -45,7 +45,7 @@
                   <span v-html="$t('軽症・<br />中等症')" />
                   <!-- eslint-enable vue/no-v-html-->
                   <span>
-                    <b>{{ 軽症中等症 }}</b>
+                    <b>{{ 軽症中等症 || '-' }}</b>
                     <span class="unit">{{ $t('人') }}</span>
                   </span>
                 </div>
@@ -56,7 +56,7 @@
                 <div class="box short">
                   <span>{{ $t('重症') }}</span>
                   <span>
-                    <b>{{ 重症 }}</b>
+                    <b>{{ 重症 || '-' }}</b>
                     <span class="unit">{{ $t('人') }}</span>
                   </span>
                 </div>
@@ -69,7 +69,7 @@
             <div class="box">
               <span>{{ $t('死亡') }}</span>
               <span>
-                <b>{{ 死亡 }}</b>
+                <b>{{ 死亡 || '-' }}</b>
                 <span class="unit">{{ $t('人') }}</span>
               </span>
             </div>
@@ -80,7 +80,7 @@
             <div class="box">
               <span>{{ $t('退院') }}</span>
               <span>
-                <b>{{ 退院 }}</b>
+                <b>{{ 退院 || '-' }}</b>
                 <span class="unit">{{ $t('人') }}</span>
               </span>
             </div>

--- a/data/data.json
+++ b/data/data.json
@@ -1048,25 +1048,25 @@
                 "children": [
                     {
                         "attr": "入院中",
-                        "value": 0,
+                        "value": null,
                         "children": [
                             {
                                 "attr": "軽症・中等症",
-                                "value": 0
+                                "value": null
                             },
                             {
                                 "attr": "重症",
-                                "value": 0
+                                "value": null
                             }
                         ]
                     },
                     {
                         "attr": "退院",
-                        "value": 0
+                        "value": null
                     },
                     {
                         "attr": "死亡",
-                        "value": 0
+                        "value": null
                     }
                 ]
             }

--- a/utils/formatConfirmedCases.ts
+++ b/utils/formatConfirmedCases.ts
@@ -1,32 +1,32 @@
 type DataType = {
   attr: '検査実施人数'
-  value: number
+  value: number | null
   children: [
     {
       attr: '陽性患者数'
-      value: number
+      value: number | null
       children: [
         {
           attr: '入院中'
-          value: number
+          value: number | null
           children: [
             {
               attr: '軽症・中等症'
-              value: number
+              value: number | null
             },
             {
               attr: '重症'
-              value: number
+              value: number | null
             }
           ]
         },
         {
           attr: '退院'
-          value: number
+          value: number | null
         },
         {
           attr: '死亡'
-          value: number
+          value: number | null
         }
       ]
     }
@@ -34,13 +34,13 @@ type DataType = {
 }
 
 type ConfirmedCasesType = {
-  検査実施人数: number
-  陽性物数: number
-  入院中: number
-  軽症中等症: number
-  重症: number
-  死亡: number
-  退院: number
+  検査実施人数: number | null
+  陽性物数: number | null
+  入院中: number | null
+  軽症中等症: number | null
+  重症: number | null
+  死亡: number | null
+  退院: number | null
 }
 
 /**


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #59

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
- 「検査陽性者の状況」の未取得データを0からハイフン'-'に変更
- data.jsonのmain_summary各valueがnullである場合に未取得データと認識する。
- data.jsonのvalueにnullを設定できない場合は、別の実装方法で対応した方がいいので、レビューください。

## 📸 スクリーンショット / Screenshots
![localhost_3000_](https://user-images.githubusercontent.com/2687755/77022348-bb9b8d80-69cc-11ea-968a-cf7f996dc514.png)
