### PR TITLE
fixed 'contact us' url link.

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -156,7 +156,7 @@
       </i18n>
     </TextCard>
     <TextCard :title="$t('お問い合わせ先（HPサイトポリシーについて）')">
-      <a href="https://c4ngt.connpass.com/">Code For Niigata</a>
+      <a href="https://www.codeforniigata.org/">Code For Niigata</a>
     </TextCard>
   </div>
 </template>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #67

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
- 問い合わせ先のリンク先を「codeforniigata.org」に変更
![localhost_3000_about](https://user-images.githubusercontent.com/2687755/77026912-256d6480-69d8-11ea-8389-5b3c8f0c78fa.png)
