### PR TITLE
improve sidebar layout using 'figure'

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -52,7 +52,7 @@
             <figure>
               <img src="/twitter.png" alt="Twitter" />
               <figcaption>
-                新潟市<br>危機管理防災局
+                新潟市<br />危機管理防災局
               </figcaption>
             </figure>
           </a>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -49,16 +49,24 @@
             target="_blank"
             rel="noopener"
           >
-            <img src="/twitter.png" alt="Twitter" />
-            新潟市危機管理防災局
+            <figure>
+              <img src="/twitter.png" alt="Twitter" />
+              <figcaption>
+                新潟市<br>危機管理防災局
+              </figcaption>
+            </figure>
           </a>
           <a
             href="https://twitter.com/Niigata_Press"
             target="_blank"
             rel="noopener"
           >
-            <img src="/twitter.png" alt="Twitter" />
-            新潟県広報課
+            <figure>
+              <img src="/twitter.png" alt="Twitter" />
+              <figcaption>
+                新潟県広報課
+              </figcaption>
+            </figure>
           </a>
           <a
             href="https://github.com/CodeForNiigata/covid19"
@@ -244,10 +252,16 @@ export default {
   &-SocialLinkContainer {
     display: flex;
     & a:not(:last-of-type) {
-      margin-right: 10px;
+      margin-right: 5px;
     }
     & img {
       width: 30px;
+    }
+    & figure {
+      text-align: center;
+      & figcaption {
+        font-size: 10px;
+      }
     }
   }
   &-Copyright {

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -51,9 +51,7 @@
           >
             <figure>
               <img src="/twitter.png" alt="Twitter" />
-              <figcaption>
-                新潟市<br />危機管理防災局
-              </figcaption>
+              <figcaption>新潟市<br />危機管理防災局</figcaption>
             </figure>
           </a>
           <a
@@ -63,9 +61,7 @@
           >
             <figure>
               <img src="/twitter.png" alt="Twitter" />
-              <figcaption>
-                新潟県広報課
-              </figcaption>
+              <figcaption>新潟県広報課</figcaption>
             </figure>
           </a>
           <a


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #63

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
- サイドバーのアイコンのレイアウトを調整
- アイコンの下に文字が来るように
- フォントサイズを小さく
- figureタグとfigcaptionタグを使用

## 📸 スクリーンショット / Screenshots
![localhost_3000_about](https://user-images.githubusercontent.com/2687755/77032937-34a8de00-69e9-11ea-84f5-ca3a57300d3f.png)
