### PR TITLE
エラーが出るため不要なrouteを削除した

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -196,10 +196,7 @@ const config: Configuration = {
         '/cards/number-of-confirmed-cases',
         '/cards/attributes-of-confirmed-cases',
         '/cards/number-of-tested',
-        '/cards/number-of-reports-to-covid19-telephone-advisory-center',
-        '/cards/number-of-reports-to-covid19-consultation-desk',
-        '/cards/predicted-number-of-toei-subway-passengers',
-        '/cards/agency'
+        '/cards/number-of-reports-to-covid19-consultation-desk'
       ]
 
       const routes: string[] = []

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -190,7 +190,7 @@ const config: Configuration = {
   generate: {
     fallback: true,
     routes() {
-      const locales = ['ja', 'en', 'zh-cn', 'zh-tw', 'ko', 'ja-basic']
+      const locales = ['ja']
       const pages = [
         '/cards/details-of-confirmed-cases',
         '/cards/number-of-confirmed-cases',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #90

## ⛏ 変更内容 / Details of Changes

- 新潟版にはデータがないため表示不要なページのrouteを削除しました。
  - 新型コロナコールセンター相談件数
  - 都営地下鉄の利用者数の推移
  - 都庁来庁者数の推移
- 新潟版はまだ他言語の対応はしていないため、日本語以外のrouteも削除しました。

## 📸 スクリーンショット / Screenshots

以下のエラー以外はなくなりました。
- ` ERROR  Webpack mode only works with build.extractCSS set to *true*. Either extract your CSS or use 'postcss' mode`

![Screen Shot 2020-03-20 at 14 33 27](https://user-images.githubusercontent.com/5251092/77139094-06460400-6ab8-11ea-9b29-2799e2579a7e.png)
