### PR TITLE
Hotfix/#10 #update meta ogp twitter

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -83,7 +83,7 @@ export default Vue.extend({
       link: [
         {
           rel: 'canonical',
-          href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+          href: `https://niigata.stopcovid19.jp${this.$route.path}`
         }
       ]
     }

--- a/layouts/print.vue
+++ b/layouts/print.vue
@@ -77,7 +77,7 @@ export default {
       link: [
         {
           rel: 'canonical',
-          href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+          href: `https://niigata.stopcovid19.jp${this.$route.path}`
         }
       ]
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -32,7 +32,7 @@ const config: Configuration = {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://dev-niigata-informal.netlify.com/'
+        content: 'https://niigata.stopcovid19.jp/'
       },
       {
         hid: 'og:title',
@@ -48,8 +48,7 @@ const config: Configuration = {
       {
         hid: 'og:image',
         property: 'og:image',
-        content:
-          'https://github.com/CodeForNiigata/covid19/blob/development/static/ogp.png'
+        content: 'https://niigata.stopcovid19.jp/ogp.png'
       },
       {
         hid: 'twitter:card',
@@ -59,23 +58,22 @@ const config: Configuration = {
       {
         hid: 'twitter:site',
         name: 'twitter:site',
-        content: '@tokyo_bousai'
+        content: '@code4niigata'
       },
       {
         hid: 'twitter:creator',
         name: 'twitter:creator',
-        content: '@tokyo_bousai'
+        content: '@code4niigata'
       },
       {
         hid: 'twitter:image',
         name: 'twitter:image',
-        content:
-          'https://github.com/CodeForNiigata/covid19/blob/development/static/ogp.png'
+        content: 'https://niigata.stopcovid19.jp/ogp.png'
       },
       {
         hid: 'fb:app_id',
         property: 'fb:app_id',
-        content: '2879625188795443'
+        content: '208665406903237'
       },
       {
         hid: 'note:card',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #10

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
- 以下のmeta情報を修正
    - og:url
        - 本番サイトのURL`https://niigata.stopcovid19.jp/`に変更
    - og:image
        - 本番サイトのURL`https://niigata.stopcovid19.jp/`に変更
    - twitter:site
        - `@code4niigata` に変更
    - twitter:creator
        - `@code4niigata` に変更
    - twitter:image
        - 本番サイトのURL`https://niigata.stopcovid19.jp/`に変更
    - fb:app_id
        - Code for Niigataで取得したIDを設定
    - canonical
        - 本番サイトのURLに変更

