### PR TITLE
3/21 新潟市tweetから更新

### DIFF
--- a/data/news.json
+++ b/data/news.json
@@ -1,6 +1,11 @@
 {
     "newsItems": [
         {
+            "date": "2020\/3\/21",
+            "url": "https://www.city.niigata.lg.jp/iryo/kenko/yobou_kansen/kansen/coronavirus.files/press0321.pdf",
+            "text": "新潟市危機管理防災局：本日、新たに１名の方の新型コロナウイルス感染症の感染が確認され、市内の累計感染者数は２５名（新潟県内２７名）となりました。"
+        },
+        {
             "date": "2020\/3\/20",
             "url": "https://www.city.niigata.lg.jp/iryo/kenko/yobou_kansen/kansen/coronavirus.files/press3.20.pdf",
             "text": "新潟県防災局：3/20】新潟市で、新たにコロナウイルス感染症に感染された方１名が確認されました。いずれも既に発表されている患者の濃厚接触者とのことです。⑴新潟市江南区・30代・女性県内の感染者の累計は25件です。引き続き、皆様には感染防止に努めていただくようお願いします。"


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #86
## ⛏ 変更内容 / Details of Changes
新潟市危機管理防災局
@niigatacity_kib
本日、新たに１名の方の新型コロナウイルス感染症の感染が確認され、市内の累計感染者数は２５名（新潟県内２７名）となりました
