### PR TITLE
masterにコミット時、最終更新時間を現在時刻で更新するGitHub Actionを追加

### DIFF
--- a/.github/workflows/update_lastupdate.yml
+++ b/.github/workflows/update_lastupdate.yml
@@ -1,0 +1,26 @@
+name: update lastupdate
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Commit files
+        run: |
+          D=$(date '+%Y-%m-%d %H:%M') && sed -i data/data.json -e "s/\"lastUpdate\"\:.*/\"lastUpdate\"\:\ \"${D//-/\\\/}\",/"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add data/data.json
+          git commit -m "Updates datetime of last update."
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: master
+          force: true


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #106

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 最新のお知らせの更新時間を、masterにコミット時の現在時刻で更新する。
- GitHub Actionのpushイベントをトリガーにして、data/data.jsonのlastupdateを更新する。

- 更新時のコミットメッセージ、user.name, user.emailは、わかりやすいものに変えてもらったほうが良いかもしれません。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- なし
