### PR TITLE
日付別グラフに土日祝がわかるように色分け

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -115,7 +115,9 @@ export default {
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: '#3b64b0',
+              backgroundColor: this.chartData.map(d => {
+                return d.bgColor
+              }),
               borderWidth: 0
             }
           ]
@@ -131,7 +133,9 @@ export default {
             data: this.chartData.map(d => {
               return d.cumulative
             }),
-            backgroundColor: '#3b64b0',
+            backgroundColor: this.chartData.map(d => {
+              return d.bgColor
+            }),
             borderWidth: 0
           }
         ]

--- a/utils/formatGraph.ts
+++ b/utils/formatGraph.ts
@@ -4,6 +4,7 @@ type DataType = {
 }
 
 type GraphDataType = {
+  bgColor: string
   label: string
   transition: number
   cumulative: number
@@ -24,8 +25,15 @@ export default (data: DataType[]) => {
       const date = new Date(d['日付'])
       const subTotal = d['小計']
       if (!isNaN(subTotal)) {
+        const col =
+          date.getDay() === 0
+            ? `#FF0000`
+            : date.getDay() === 6
+            ? `#3CB371`
+            : `#3b64b0`
         patSum += subTotal
         graphData.push({
+          bgColor: col,
           label: `${date.getMonth() + 1}/${date.getDate()}`,
           transition: subTotal,
           cumulative: patSum


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #287

## 📝 関連する issue / Related Issues
- #287

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- graphdata にbgColorを追加
- bgColorを利用して棒グラフに色

## 📸 スクリーンショット / Screenshots
[![Image from Gyazo](https://i.gyazo.com/ea52a24ad31ef5920fda94fe7bab3a41.png)](https://gyazo.com/ea52a24ad31ef5920fda94fe7bab3a41)